### PR TITLE
User story 18 and 19 - User Profile and Edit

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,8 +6,9 @@ class SessionsController<ApplicationController
 
   def create
     user = User.find_by(email: params[:email])
-    flash[:success] = "Welcome, #{user.name}!"
+
     if user && user.authenticate(params[:password])
+      flash[:success] = "Welcome, #{user.name}!"
       session[:user_id] = user.id
       if user.admin_user?
         redirect_to "/admin"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,6 +22,7 @@ class UsersController<ApplicationController
   def update
     @user = current_user
     @user.update(user_params)
+
     if @user.save
       redirect_to "/profile"
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,6 +15,21 @@ class UsersController<ApplicationController
     render :profile
   end
 
+  def edit
+    @user = current_user
+  end
+
+  def update
+    @user = current_user
+    @user.update(user_params)
+    if @user.save
+      redirect_to "/profile"
+    else
+      flash[:error] = @user.errors.full_messages.to_sentence
+      redirect_to "/profile/edit"
+    end
+  end
+
   private
   def user_params
     params.permit(:name, :address, :city, :state, :zipcode, :email, :password, :password_confirmation)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,7 @@ class UsersController<ApplicationController
   end
 
   def show
-    @user = User.find(session[:user_id])
+    @user = current_user
     render :profile
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,6 +24,7 @@ class UsersController<ApplicationController
     @user.update(user_params)
 
     if @user.save
+      flash[:sucess] = "Your profile has been updated"
       redirect_to "/profile"
     else
       flash[:error] = @user.errors.full_messages.to_sentence

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_secure_password
+  
   validates_presence_of :name, :address, :city, :state, :zipcode, :password_digest
   validates :email,
             uniqueness: true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   validates :email,
             uniqueness: true,
             presence: true
-  validates_format_of :email, with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, on: :create
+  validates_format_of :email, with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
 
   enum role: [:regular_user, :merchant_employee, :merchant_admin, :admin_user]
 end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -14,10 +14,10 @@
     <%= text_field_tag :state, "#{@user.state}" %>
 
     <%= label_tag :zipcode %>
-    <%= text_field_tag :zipcode,"#{@user.zipcode}" %>
+    <%= text_field_tag :zipcode, "#{@user.zipcode}" %>
 
     <%= label_tag :email %>
-    <%= text_field_tag :email,"#{@user.email}" %>
+    <%= text_field_tag :email, "#{@user.email}" %>
 
     <%= submit_tag 'Update Profile' %>
   <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,24 +1,36 @@
-
-<center>
+<h1> Update User Profile</h1>
+<section id= "user-profile-edit-form">
   <%= form_tag "/profile", method: :patch do %>
-    <%= label_tag :name %>
-    <%= text_field_tag :name, "#{@user.name}"%>
+    <div class="form-group">
+      <%= label_tag :name %>
+      <%= text_field_tag :name, "#{@user.name}"%>
+    </div>
 
-    <%= label_tag :address %>
-    <%= text_field_tag :address, "#{@user.address}" %>
+    <div class="form-group">
+      <%= label_tag :address %>
+      <%= text_field_tag :address, "#{@user.address}" %>
+    </div>
 
-    <%= label_tag :city %>
-    <%= text_field_tag :city, "#{@user.city}" %>
+    <div class="form-group">
+      <%= label_tag :city %>
+      <%= text_field_tag :city, "#{@user.city}" %>
+    </div>
 
-    <%= label_tag :state %>
-    <%= text_field_tag :state, "#{@user.state}" %>
+    <div class="form-group">
+      <%= label_tag :state %>
+      <%= text_field_tag :state, "#{@user.state}" %>
+    </div>
 
+  <div class="form-group">
     <%= label_tag :zipcode %>
     <%= text_field_tag :zipcode, "#{@user.zipcode}" %>
+  </div>
 
+  <div class="form-group">
     <%= label_tag :email %>
     <%= text_field_tag :email, "#{@user.email}" %>
+  </div>
 
     <%= submit_tag 'Update Profile' %>
   <% end %>
-</center>
+</section>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,24 @@
+
+<center>
+  <%= form_tag "/profile", method: :patch do %>
+    <%= label_tag :name %>
+    <%= text_field_tag :name, "#{@user.name}"%>
+
+    <%= label_tag :address %>
+    <%= text_field_tag :address, "#{@user.address}" %>
+
+    <%= label_tag :city %>
+    <%= text_field_tag :city, "#{@user.city}" %>
+
+    <%= label_tag :state %>
+    <%= text_field_tag :state, "#{@user.state}" %>
+
+    <%= label_tag :zipcode %>
+    <%= text_field_tag :zipcode,"#{@user.zipcode}" %>
+
+    <%= label_tag :email %>
+    <%= text_field_tag :email,"#{@user.email}" %>
+
+    <%= submit_tag 'Update Profile' %>
+  <% end %>
+</center>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -1,1 +1,17 @@
-<h1>Hello, <%= @user.name %>!</h1>
+
+<div class="jumbotron">
+  <section id="user-info-<%=@user.id %>">
+  <h1 class="display-4">Hello, <%= @user.name %>!</h1>
+    <p class="lead">Address: <%= @user.address %></p>
+    <p class="lead">City: <%= @user.city %></p>
+    <p class="lead">State: <%= @user.state %></p>
+    <p class="lead">Zipcode: <%= @user.zipcode %></p>
+    <p class="lead">Email: <%= @user.email %></p>
+  </section>
+
+  <section id= "user-profile-actions">
+    <p class="lead">
+      <a class="btn btn-primary btn-lg" href="#" role="button">Edit Profile</a>
+    </p>
+  </section>
+</div>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -11,7 +11,8 @@
 
   <section id= "user-profile-actions">
     <p class="lead">
-      <a class="btn btn-primary btn-lg" href="#" role="button">Edit Profile</a>
+      <a class="btn btn-primary btn-lg" href="#" role="button"> <%= link_to "Edit Profile", "profile/edit" %>
+      </a>
     </p>
   </section>
 </div>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -11,8 +11,7 @@
 
   <section id= "user-profile-actions">
     <p class="lead">
-      <a class="btn btn-primary btn-lg" href="#" role="button"> <%= link_to "Edit Profile", "profile/edit" %>
-      </a>
+       <%= link_to "Edit Profile", "profile/edit" %>
     </p>
   </section>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
   post "/users", to: "users#create"
 
   get "/profile", to: "users#show"
+  get "/profile/edit", to: "users#edit"
+  patch "/profile", to: "users#update"
 
   namespace :merchant do
     get "/", to: "dashboard#index"

--- a/spec/features/users/regular_users/edit_spec.rb
+++ b/spec/features/users/regular_users/edit_spec.rb
@@ -39,13 +39,11 @@ RSpec.describe "User Profile" do
     expect(page).to have_content("chicken@email.com")
   end
 
-  it 'cannot enter invalid or nil information' do
+  it 'cannot user enter nil information' do
 
     within "#user-profile-actions" do
       click_link("Edit Profile")
     end
-
-    expect(current_path).to eq("/profile/edit")
 
     fill_in :name, with: "Adam Smith"
     fill_in :address, with: "1234 Happy St"
@@ -57,5 +55,24 @@ RSpec.describe "User Profile" do
     click_button "Update Profile"
 
     expect(current_path).to eq("/profile/edit")
+    expect(page).to have_content("City can't be blank and Zipcode can't be blank")
+  end
+
+  it 'user cannot enter invalid email' do
+    within "#user-profile-actions" do
+      click_link("Edit Profile")
+    end
+
+    fill_in :name, with: "Adam Smith"
+    fill_in :address, with: "1234 Happy St"
+    fill_in :city, with: "Denver"
+    fill_in :state, with: "CO"
+    fill_in :zipcode, with: "80205"
+    fill_in :email, with: "waffle"
+
+    click_button "Update Profile"
+
+    expect(current_path).to eq("/profile/edit")
+    expect(page).to have_content("Email is invalid")
   end
 end

--- a/spec/features/users/regular_users/edit_spec.rb
+++ b/spec/features/users/regular_users/edit_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe "User Profile" do
+  before :each do
+    @regular_user = User.create!(name: "George Jungle",
+                  address: "1 Jungle Way",
+                  city: "Jungleopolis",
+                  state: "FL",
+                  zipcode: "77652",
+                  email: "junglegeorge@email.com",
+                  password: "Tree123")
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@regular_user)
+    visit '/profile'
+  end
+
+  it 'can edit user information' do
+
+    within "#user-profile-actions" do
+      click_link("Edit Profile")
+    end
+
+    expect(current_path).to eq("/profile/edit")
+
+    fill_in :name, with: "Adam Smith"
+    fill_in :address, with: "1234 Happy St"
+    fill_in :city, with: "Denver"
+    fill_in :state, with: "CO"
+    fill_in :zipcode, with: "80204"
+    fill_in :email, with: "chicken@email.com"
+
+    click_button "Update Profile"
+
+    expect(current_path).to eq("/profile")
+    expect(page).to have_content("Adam Smith")
+    expect(page).to have_content("1234 Happy St")
+    expect(page).to have_content("Denver")
+    expect(page).to have_content("CO")
+    expect(page).to have_content("chicken@email.com")
+  end
+
+  it 'cannot enter invalid or nil information' do
+
+    within "#user-profile-actions" do
+      click_link("Edit Profile")
+    end
+
+    expect(current_path).to eq("/profile/edit")
+
+    fill_in :name, with: "Adam Smith"
+    fill_in :address, with: "1234 Happy St"
+    fill_in :city, with: ""
+    fill_in :state, with: "CO"
+    fill_in :zipcode, with: ""
+    fill_in :email, with: "chicken@email.com"
+
+    click_button "Update Profile"
+
+    expect(current_path).to eq("/profile/edit")
+  end
+end

--- a/spec/features/users/regular_users/edit_spec.rb
+++ b/spec/features/users/regular_users/edit_spec.rb
@@ -1,5 +1,17 @@
 require 'rails_helper'
 
+# As a registered user
+# When I visit my profile page OK
+# I see a link to edit my profile data OK
+# When I click on the link to edit my profile data OK
+# I see a form like the registration page OK
+# The form is prepopulated with all my current information except my password NEEDED
+# When I change any or all of that information OK
+# And I submit the form OK
+# Then I am returned to my profile page OK
+# And I see a flash message telling me that my data is updated NEEDED
+# And I see my updated information OK
+
 RSpec.describe "User Profile" do
   before :each do
     @regular_user = User.create!(name: "George Jungle",

--- a/spec/features/users/regular_users/edit_spec.rb
+++ b/spec/features/users/regular_users/edit_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "User Profile" do
     expect(page).to have_content("Your profile has been updated")
   end
 
-  it 'cannot user enter nil information' do
+  it 'user cannot enter nil information' do
 
     within "#user-profile-actions" do
       click_link("Edit Profile")

--- a/spec/features/users/regular_users/edit_spec.rb
+++ b/spec/features/users/regular_users/edit_spec.rb
@@ -1,17 +1,5 @@
 require 'rails_helper'
 
-# As a registered user
-# When I visit my profile page OK
-# I see a link to edit my profile data OK
-# When I click on the link to edit my profile data OK
-# I see a form like the registration page OK
-# The form is prepopulated with all my current information except my password OK
-# When I change any or all of that information OK
-# And I submit the form OK
-# Then I am returned to my profile page OK
-# And I see a flash message telling me that my data is updated NEEDED
-# And I see my updated information OK
-
 RSpec.describe "User Profile" do
   before :each do
     @regular_user = User.create!(name: "George Jungle",

--- a/spec/features/users/regular_users/edit_spec.rb
+++ b/spec/features/users/regular_users/edit_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 # I see a link to edit my profile data OK
 # When I click on the link to edit my profile data OK
 # I see a form like the registration page OK
-# The form is prepopulated with all my current information except my password NEEDED
+# The form is prepopulated with all my current information except my password OK
 # When I change any or all of that information OK
 # And I submit the form OK
 # Then I am returned to my profile page OK
@@ -49,6 +49,7 @@ RSpec.describe "User Profile" do
     expect(page).to have_content("Denver")
     expect(page).to have_content("CO")
     expect(page).to have_content("chicken@email.com")
+    expect(page).to have_content("Your profile has been updated")
   end
 
   it 'cannot user enter nil information' do

--- a/spec/features/users/regular_users/show_spec.rb
+++ b/spec/features/users/regular_users/show_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe "User Profile" do
+  before :each do
+    @regular_user = User.create!(name: "George Jungle",
+                  address: "1 Jungle Way",
+                  city: "Jungleopolis",
+                  state: "FL",
+                  zipcode: "77652",
+                  email: "junglegeorge@email.com",
+                  password: "Tree123")
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@regular_user)
+    visit '/profile'
+  end
+
+  it 'can show the users info' do
+
+    within "#user-info-#{@regular_user.id}" do
+      expect(page).to have_content(@regular_user.name)
+      expect(page).to have_content(@regular_user.city)
+      expect(page).to have_content(@regular_user.zipcode)
+      expect(page).to have_content(@regular_user.email)
+      expect(page).to have_content(@regular_user.name)
+    end
+
+    within "#user-profile-actions" do
+      expect(page).to have_link("Edit Profile")
+    end
+  end
+end


### PR DESCRIPTION
- regular user profile show users info expect for password
- **updated show method in user controller to set @user = current_user**. This allows us to stub logins
- Why do we need to update @user to equal current_user inorder to use a stub (question from previous pull request)? "So basically, in the user#show method, if we leave the @user =User.find(session[:user_id]), it cannot find the session[:user_id], since we never actually login in to start that session. So by setting @user equal to current_user instead, we can just stub any instance of 'current_user' from the application controller with our test object @regular_users... so we don't have to rely on a session[:user_id] find the user in the db." https://stackoverflow.com/questions/7448974/how-to-stub-applicationcontroller-method-in-request-spec

- users can edit profile 
- sad path if user enters nil field, invalid emails, or already used email

- Rspec OK 
- SimpleCov 99.86% (Missing coverage for session controller method create, needs sad path test if visitor does not enter in correct information.)