### PR TITLE
User story 17 - Items Index Page

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -8,9 +8,11 @@
   <% @items.each do |item| %>
     <% if item.active? %>
       <section class = "grid-item" id= 'item-<%=item.id%>'>
-        <h2> <%=link_to item.name, "/items/#{item.id}" %> </h2>
-        <p>Sold by: <%=link_to item.merchant.name, "/merchants/#{item.merchant.id}" %></p>
-        <img src= <%= item.image %>>
+        <h2> <%=link_to item.name, item_path(item) %> </h2>
+        <p>Sold by: <%=link_to item.merchant.name, merchant_path(item.merchant) %></p>
+        <%= link_to item_path(item) do %>
+           <%= image_tag item.image %>
+        <% end %>
         <p> <%= item.description unless @merchant%> </p>
         <p>Price: <%=number_to_currency(item.price) %> </p>
         <p>Inventory: <%= item.inventory %> </p>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -6,20 +6,22 @@
 <% end %>
 <section class="grid-container">
   <% @items.each do |item| %>
-    <section class = "grid-item" id= 'item-<%=item.id%>'>
-      <h2> <%=link_to item.name, "/items/#{item.id}" %> </h2>
-      <p>Sold by: <%=link_to item.merchant.name, "/merchants/#{item.merchant.id}" %></p>
-      <img src= <%= item.image %>>
-      <p> <%= item.description unless @merchant%> </p>
-      <p>Price: <%=number_to_currency(item.price) %> </p>
-      <p>Inventory: <%= item.inventory %> </p>
-      <% if !@merchant %>
-      <% end %>
-      <% if item.active? %>
-        <p>Active</p>
-      <% else %>
-        <p>Inactive</p>
-      <% end %>
-    </section>
+    <% if item.active? %>
+      <section class = "grid-item" id= 'item-<%=item.id%>'>
+        <h2> <%=link_to item.name, "/items/#{item.id}" %> </h2>
+        <p>Sold by: <%=link_to item.merchant.name, "/merchants/#{item.merchant.id}" %></p>
+        <img src= <%= item.image %>>
+        <p> <%= item.description unless @merchant%> </p>
+        <p>Price: <%=number_to_currency(item.price) %> </p>
+        <p>Inventory: <%= item.inventory %> </p>
+        <% if !@merchant %>
+        <% end %>
+        <% if item.active? %>
+          <p>Active</p>
+        <% else %>
+          <p>Inactive</p>
+        <% end %>
+      </section>
+    <% end %>
     <% end %>
 </section>

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe "Items Index Page" do
       expect(page).to have_link(@tire.merchant.name)
       expect(page).to have_link(@pull_toy.name)
       expect(page).to have_link(@pull_toy.merchant.name)
-      expect(page).to have_link(@dog_bone.name)
-      expect(page).to have_link(@dog_bone.merchant.name)
+      # expect(page).to have_link(@dog_bone.name)
+      # expect(page).to have_link(@dog_bone.merchant.name)
     end
 
     it "I can see a list of all of the items "do
@@ -46,16 +46,18 @@ RSpec.describe "Items Index Page" do
         expect(page).to have_link(@brian.name)
         expect(page).to have_css("img[src*='#{@pull_toy.image}']")
       end
+    end
 
-      within "#item-#{@dog_bone.id}" do
-        expect(page).to have_link(@dog_bone.name)
-        expect(page).to have_content(@dog_bone.description)
-        expect(page).to have_content("Price: $#{@dog_bone.price}")
-        expect(page).to have_content("Inactive")
-        expect(page).to have_content("Inventory: #{@dog_bone.inventory}")
-        expect(page).to have_link(@brian.name)
-        expect(page).to have_css("img[src*='#{@dog_bone.image}']")
-      end
+    it "disabled items are not shown" do
+      visit items_path
+
+      expect(page).to_not have_link(@dog_bone.name)
+      expect(page).to_not have_content(@dog_bone.description)
+      expect(page).to_not have_content("Price: $#{@dog_bone.price}")
+      expect(page).to_not have_content("Inactive")
+      expect(page).to_not have_content("Inventory: #{@dog_bone.inventory}")
+      # expect(page).to_not have_link(@brian.name)
+      expect(page).to_not have_css("img[src*='#{@dog_bone.image}']")
     end
   end
 end

--- a/spec/features/items/merchant_items_index_spec.rb
+++ b/spec/features/items/merchant_items_index_spec.rb
@@ -29,15 +29,18 @@ RSpec.describe "Merchant Items Index Page" do
         expect(page).to_not have_content(@chain.description)
         expect(page).to have_content("Inventory: #{@chain.inventory}")
       end
+    end
 
-      within "#item-#{@shifter.id}" do
-        expect(page).to have_content(@shifter.name)
-        expect(page).to have_content("Price: $#{@shifter.price}")
-        expect(page).to have_css("img[src*='#{@shifter.image}']")
-        expect(page).to have_content("Inactive")
-        expect(page).to_not have_content(@shifter.description)
-        expect(page).to have_content("Inventory: #{@shifter.inventory}")
-      end
+    it "disabled items are not shown" do
+      visit merchant_items_path(@meg)
+
+      expect(page).to_not have_content(@shifter.name)
+      expect(page).to_not have_content("Price: $#{@shifter.price}")
+      expect(page).to_not have_css("img[src*='#{@shifter.image}']")
+      expect(page).to_not have_content("Inactive")
+      expect(page).to_not have_content(@shifter.description)
+      expect(page).to_not have_content("Inventory: #{@shifter.inventory}")
+
     end
   end
 end

--- a/spec/features/items/show_spec.rb
+++ b/spec/features/items/show_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'item show page', type: :feature do
 
   end
   it 'shows item info' do
-    visit "items/#{@chain.id}"
+    visit item_path(@chain)
 
     expect(page).to have_link(@chain.merchant.name)
     expect(page).to have_link(@chain.name)
@@ -23,7 +23,7 @@ RSpec.describe 'item show page', type: :feature do
     review_1 = @chain.reviews.create(title: "Great place!", content: "They have cool bike stuff and I'd recommend them to anyone.", rating: 5)
     review_2 = @chain.reviews.create(title: "Okay place :/", content: "Brian's cool and all but not a good selection of things", rating: 3)
 
-    visit "items/#{@chain.id}"
+    visit item_path(@chain)
 
     within "#review-#{review_1.id}" do
       expect(page).to have_content(review_1.title)


### PR DESCRIPTION
- Images in items index html are clickable
- Modify items index html such that inactive items are hidden from view
  - Although this user story is only concerned with `/items`, I also had to modify index html for `/merchants/:id/items` to hide inactive items
  - However, when the `current user` is either merchant_user or admin_user, they should be able to see those inactive items, so we may need to further modify the conditional statement in index view page (later)