### PR TITLE
Add a link to My Orders on profile page

### DIFF
--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -15,4 +15,6 @@
        <%= link_to "Edit Profile", "profile/edit" %>
     </p>
   </section>
+
+  <%= link_to "My Orders", "/profile/orders" %>
 </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 20190907174755) do
 
   # These are extensions that must be enabled in order to support this database

--- a/spec/features/users/regular_user/profile_order_spec.rb
+++ b/spec/features/users/regular_user/profile_order_spec.rb
@@ -1,18 +1,3 @@
-# User Story 23
-# As a registered user
-# When I add items to my cart
-# And I visit my cart
-# I see a button or link indicating that I can check out
-# And I click the button or link to check out
-#
-# An order is created in the system,
-# which has a status of "pending"
-# That order is associated with my user
-# I am taken to my orders page ("/profile/orders")
-# I see a flash message telling me my order was created
-# I see my new order listed on my profile orders page
-# My cart is now empty
-
 require 'rails_helper'
 
 RSpec.describe "User Profile Order Page" do
@@ -21,12 +6,21 @@ RSpec.describe "User Profile Order Page" do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
 
     merchant_1 = create(:merchant)
+
     @item_1 = merchant_1.items.create!(attributes_for(:item))
     @item_2 = merchant_1.items.create!(attributes_for(:item))
 
     @order_1 = create(:order)
     @item_order_1 = @user.item_orders.create!(order: @order_1, item: @item_1, quantity: 1, price: @item_1.price)
     @item_order_2 = @user.item_orders.create!(order: @order_1, item: @item_2, quantity: 1, price: @item_2.price)
+  end
+
+  it "see a link to my orders" do
+    visit profile_path
+
+    expect(page).to have_link("My Orders")
+    click_link("My Orders")
+    expect(current_path).to eq("/profile/orders")
   end
 
   it "see a list of my orders and a flash message confirming my recent order" do


### PR DESCRIPTION
Add a link to `My Orders` on profile page, which is routed to `/profile/orders`