### PR TITLE
User story 26

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -153,6 +153,14 @@ td, th {
   padding: 8px;
 }
 
-tr:nth-child(even) {
-  background-color: #F0F8FF;
+.img_thumbnail {
+  width: 20%;
+}
+
+.table > thead > tr > th {
+  vertical-align: middle;
+}
+
+.table > tbody > tr > td {
+  vertical-align: middle;
 }

--- a/app/models/item_order.rb
+++ b/app/models/item_order.rb
@@ -8,4 +8,12 @@ class ItemOrder <ApplicationRecord
   def subtotal
     price * quantity
   end
+
+  def self.total_quantity_per_order(order_id)
+    where(order_id: order_id).sum(:quantity)
+  end
+
+  def self.grandtotal_per_order(order_id)
+    find_by(order_id: order_id).order.grandtotal
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -9,9 +9,9 @@ class Order <ApplicationRecord
   end
 
   def to_s
-    "#{self.name} \n
-    #{self.address} \n
-    #{self.city}, #{self.state} \n
+    "#{self.name}
+    #{self.address}
+    #{self.city}, #{self.state}
     #{self.zip}
     "
   end

--- a/app/views/users/show_orders.html.erb
+++ b/app/views/users/show_orders.html.erb
@@ -4,7 +4,7 @@
   <h4>Order information</h4>
 
     <table class="table">
-      <thead>
+      <thead class="thead-light">
         <tr>
           <th scope="col">Order ID</th>
           <th scope="col">Item</th>
@@ -18,28 +18,41 @@
           <th scope="col">Order Status</th>
         </tr>
       </thead>
-      <% @item_orders.each_with_index do |item_order, i| %>
-        <section id='item-order-<%= item_order.id %>'>
-          <tbody>
-            <tr>
-              <th scope="row"><%= link_to item_order.order.id, order_path(item_order.order.id) %></th>
-              <td><%= item_order.item.name %></td>
-              <td><%= item_order.item.merchant.name %></td>
-              <td><%= item_order.price %></td>
-              <td><%= item_order.quantity %></td>
-              <td><%= item_order.subtotal %></td>
-              <td><%= item_order.order.to_s %></td>
-              <td><%= item_order.created_at %></td>
-              <td><%= item_order.updated_at %></td>
-              <td><%= item_order.status %></td>
+
+      <tbody>
+        <% @item_orders.group_by(&:order_id).each_pair do |order_id, item_orders| %>
+          <% item_orders.each do |item_order| %>
+            <section id='item-order-<%= item_order.id %>'>
+                <tr>
+                  <td><%= link_to item_order.order.id, order_path(item_order.order.id) %></td>
+                  <td>
+                    <%= item_order.item.name %>
+                    <img id='thumbnail-<%= item_order.id %>'><%= image_tag item_order.item.image, class: 'img_thumbnail' %></img>
+                  </td>
+                  <td><%= item_order.item.merchant.name %></td>
+                  <td><%= item_order.price %></td>
+                  <td><%= item_order.quantity %></td>
+                  <td><%= item_order.subtotal %></td>
+                  <td><%= item_order.order.to_s %></td>
+                  <td><%= item_order.created_at %></td>
+                  <td><%= item_order.updated_at %></td>
+                  <td><%= item_order.status %></td>
+                </tr>
+            </section>
+          <% end %>
+
+          <section id='order-stats-<%= order_id %>'>
+            <tr class="table-success">
+              <td colspan=2>Total Quantity</td>
+              <td colspan=8><%= @item_orders.total_quantity_per_order(order_id) %></td>
             </tr>
 
-            <tr>
-              <th scope="col" colspan=2>Grand Total</th>
-              <td colspan=8><%= number_to_currency(item_order.order.grandtotal) %></td>
+            <tr class="table-info">
+              <td colspan=2>Grand Total</td>
+              <td colspan=8><%= number_to_currency(@item_orders.grandtotal_per_order(order_id)) %></td>
             </tr>
-          </tbody>
-        </section>
-      <% end %>
+          </section>
+        <% end %>
+      </tbody>
     </table>
 </div>

--- a/spec/features/users/regular_user/profile_order_spec.rb
+++ b/spec/features/users/regular_user/profile_order_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "User Profile Order Page" do
 
     @order_1 = create(:order)
     @item_order_1 = @user.item_orders.create!(order: @order_1, item: @item_1, quantity: 1, price: @item_1.price)
-    @item_order_2 = @user.item_orders.create!(order: @order_1, item: @item_2, quantity: 1, price: @item_2.price)
+    @item_order_2 = @user.item_orders.create!(order: @order_1, item: @item_2, quantity: 3, price: @item_2.price)
   end
 
   it "see a link to my orders" do
@@ -39,6 +39,7 @@ RSpec.describe "User Profile Order Page" do
     within "#item-order-#{@item_order_1.id}" do
       expect(page).to have_link(@order_1.id)
       expect(page).to have_content(@item_1.name)
+      expect(page).to have_css("#thumbnail-#{@item_order_1.id}")
       expect(page).to have_content(@item_1.merchant.name)
       expect(page).to have_content(@item_1.price)
       expect(page).to have_content(@item_order_1.quantity)
@@ -62,20 +63,20 @@ RSpec.describe "User Profile Order Page" do
     within "#item-order-#{@item_order_2.id}" do
       expect(page).to have_link(@order_1.id)
       expect(page).to have_content(@item_2.name)
+      expect(page).to have_css("#thumbnail-#{@item_order_2.id}")
       expect(page).to have_content(@item_2.merchant.name)
       expect(page).to have_content(@item_2.price)
       expect(page).to have_content(@item_order_2.quantity)
       expect(page).to have_content(@item_order_2.subtotal)
-      expect(page).to have_content(@order_1.name)
-      expect(page).to have_content(@order_1.address)
-      expect(page).to have_content(@order_1.city)
-      expect(page).to have_content(@order_1.state)
-      expect(page).to have_content(@order_1.zip)
+      expect(page).to have_content("#{@order_1.name} #{@order_1.address} #{@order_1.city}, #{@order_1.state} #{@order_1.zip}")
       expect(page).to have_content(@item_order_2.created_at)
       expect(page).to have_content(@item_order_2.updated_at)
       expect(page).to have_content(@item_order_2.status)
     end
 
-    expect(page).to have_content("#{@order_1.grandtotal}")
+    within "#order-stats-#{@order_1.id}" do
+      expect(page).to have_content(4)
+      expect(page).to have_content("$#{@order_1.grandtotal}")
+    end
   end
 end

--- a/spec/models/item_orders_spec.rb
+++ b/spec/models/item_orders_spec.rb
@@ -29,4 +29,24 @@ describe ItemOrder, type: :model do
     end
   end
 
+  describe 'class methods' do
+    before(:each) do
+      user = create(:user)
+      merchant_1 = create(:merchant)
+      item_1 = merchant_1.items.create!(attributes_for(:item))
+      item_2 = merchant_1.items.create!(attributes_for(:item))
+
+      @order_1 = create(:order)
+      item_order_1 = user.item_orders.create!(order: @order_1, item: item_1, quantity: 1, price: 10)
+      item_order_2 = user.item_orders.create!(order: @order_1, item: item_2, quantity: 3, price: 30)
+    end
+    
+    it 'total_quantity_per_order' do
+      expect(ItemOrder.total_quantity_per_order(@order_1.id)).to eq(4)
+    end
+
+    it 'grandtotal_per_order' do
+      expect(ItemOrder.grandtotal_per_order(@order_1.id)).to eq(100)
+    end
+  end
 end


### PR DESCRIPTION
- This user story extends from user story #25 (just adding additional item info and per-order stats in profile order page)

- In the order info table, I had to switch from using `each` to `each_pair` enumerable. When there are many items per order (aka, 1 shipping address), `total_quantity` and `grand_total` info would be displayed just once per order (not per item_order). To make this work, I had to pass in 2 parameters (`order_id`, and `item_orders`).

- There are 2 class methods in ItemOrder model. Class methods, because we are not just dealing with a single item_order instance but multiple ones, which should be sorted by `user_id` and `order_id`. Both methods are called in profile order page
  - to find the total quantity of all items, per order, by the current user
  - to find the grand total of all items, per order, by the current user