### PR TITLE
User story 32 - Merchant Order Show Page

### DIFF
--- a/app/controllers/merchant/orders_controller.rb
+++ b/app/controllers/merchant/orders_controller.rb
@@ -1,6 +1,6 @@
 class Merchant::OrdersController < Merchant::BaseController
   def show
-    order = Order.find(params[:id])
-    @item_orders = current_user.merchant.item_orders.where(order: order.id)
+    @order = Order.find(params[:id])
+    @item_orders = current_user.item_orders_by_merchant(@order.id)
   end
 end

--- a/app/controllers/merchant/orders_controller.rb
+++ b/app/controllers/merchant/orders_controller.rb
@@ -1,0 +1,6 @@
+class Merchant::OrdersController < Merchant::BaseController
+  def show
+    order = Order.find(params[:id])
+    @item_orders = current_user.merchant.item_orders.where(order: order.id)
+  end
+end

--- a/app/controllers/merchant/orders_controller.rb
+++ b/app/controllers/merchant/orders_controller.rb
@@ -2,5 +2,9 @@ class Merchant::OrdersController < Merchant::BaseController
   def show
     @order = Order.find(params[:id])
     @item_orders = current_user.item_orders_by_merchant(@order.id)
+
+    if @item_orders.empty?
+      render file: "/public/404"
+    end
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,6 +3,7 @@ class Item <ApplicationRecord
   has_many :reviews
   has_many :item_orders
   has_many :orders, through: :item_orders
+  has_many :users, through: :merchant
 
   validates_presence_of :name,
                         :description,

--- a/app/models/item_order.rb
+++ b/app/models/item_order.rb
@@ -4,6 +4,7 @@ class ItemOrder <ApplicationRecord
   belongs_to :item
   belongs_to :order
   belongs_to :user
+  has_many :merchants, through: :item
 
   def subtotal
     price * quantity

--- a/app/models/item_order.rb
+++ b/app/models/item_order.rb
@@ -17,4 +17,8 @@ class ItemOrder <ApplicationRecord
   def self.grandtotal_per_order(order_id)
     find_by(order_id: order_id).order.grandtotal
   end
+
+  def fulfilled?
+    self.status == "pending"
+  end
 end

--- a/app/models/merchant_user.rb
+++ b/app/models/merchant_user.rb
@@ -1,4 +1,8 @@
 class MerchantUser < ApplicationRecord
   belongs_to :merchant
   belongs_to :user
+
+  # def merchant_item_orders(order_id)
+  #
+  # end
 end

--- a/app/models/merchant_user.rb
+++ b/app/models/merchant_user.rb
@@ -1,8 +1,5 @@
-class MerchantUser < ApplicationRecord
-  belongs_to :merchant
-  belongs_to :user
-
-  # def merchant_item_orders(order_id)
-  #
-  # end
-end
+# TO BE DELETED
+# class MerchantUser < ApplicationRecord
+#   belongs_to :merchant
+#   belongs_to :user
+# end

--- a/app/models/merchant_user.rb
+++ b/app/models/merchant_user.rb
@@ -1,4 +1,4 @@
 class MerchantUser < ApplicationRecord
   belongs_to :merchant
-  belongs_to :user 
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,4 +14,7 @@ class User < ApplicationRecord
 
   enum role: [:regular_user, :merchant_employee, :merchant_admin, :admin_user]
 
+  def item_orders_by_merchant(order_id)
+    self.merchant.item_orders.where(order: order_id)
+  end
 end

--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -1,3 +1,24 @@
+<section id = "shipping-address">
+  <h1 align = "center">Shipping Information</h1>
+  <table>
+    <tr>
+      <th>Name</th>
+      <th>Address</th>
+      <th>City</th>
+      <th>State</th>
+      <th>Zip</th>
+    </tr>
+    <tr>
+      <td><p><%= @order.name %> </p></td>
+      <td><p><%= @order.address %> </p></td>
+      <td><p><%= @order.city %> </p></td>
+      <td><p><%= @order.state %> </p></td>
+      <td><p><%= @order.zip %> </p></td>
+    </tr>
+  </table>
+</section>
+
+
 <h1 align = "center">Order Information</h1>
 <center>
   <table>
@@ -6,7 +27,6 @@
       <th>Image</th>
       <th>Price</th>
       <th>Quantity</th>
-      <th>Subtotal</th>
     </tr>
   <% @item_orders.each do |item_order|%>
     <tr>

--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -17,8 +17,8 @@
     </tr>
   </table>
 </section>
-
-
+<br>
+<br>
 <h1 align = "center">Order Information</h1>
 <center>
   <table>
@@ -29,13 +29,13 @@
       <th>Quantity</th>
     </tr>
   <% @item_orders.each do |item_order|%>
-    <tr>
-    <section id = "item_orders-<%=item_order.id%>">
-        <td><p><%=link_to item_order.item.name, item_path(item_order.item)%></p></td>
-        <td><p><img src= <%= item_order.item.image %>><td><p>
-        <td><p><%= number_to_currency(item_order.price)%></p></td>
-        <td><p><%= item_order.quantity%></p></td>
-      </section>
-    </tr>
+  <section id = "item_orders-<%item_order.id%>">
+      <tr>
+        <td><%=link_to item_order.item.name, item_path(item_order.item)%></td>
+        <td><img src= <%= item_order.item.image %> style="width:150px;height:100px;"></img></td>
+        <td><%= number_to_currency(item_order.price)%></td>
+        <td><%= item_order.quantity%></td>
+      </tr>
+    </section>
   <% end %>
 </table>

--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -17,8 +17,10 @@
     </tr>
   </table>
 </section>
+
 <br>
 <br>
+
 <h1 align = "center">Order Information</h1>
 <center>
   <table>
@@ -28,8 +30,9 @@
       <th>Price</th>
       <th>Quantity</th>
     </tr>
+
   <% @item_orders.each do |item_order|%>
-  <section id = "item_orders-<%item_order.id%>">
+  <section id= "item-orders-<%=item_order.id%>">
       <tr>
         <td><%=link_to item_order.item.name, item_path(item_order.item)%></td>
         <td><img src= <%= item_order.item.image %> style="width:150px;height:100px;"></img></td>

--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -29,6 +29,7 @@
       <th>Image</th>
       <th>Price</th>
       <th>Quantity</th>
+      <th>Status</th>
     </tr>
 
   <% @item_orders.each do |item_order|%>
@@ -38,6 +39,11 @@
         <td><img src= <%= item_order.item.image %> style="width:150px;height:100px;"></img></td>
         <td><%= number_to_currency(item_order.price)%></td>
         <td><%= item_order.quantity%></td>
+        <% if item_order.fulfilled? %>
+            <td><%= link_to "Fulfill Item", url: "/merchant/#{@order.id}/#{item_order.id}/fulfill", method: :patch %></td>
+          <% else %>
+            <td><%= "Fulfilled" %></td>
+        <% end %>
       </tr>
     </section>
   <% end %>

--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -1,0 +1,21 @@
+<h1 align = "center">Order Information</h1>
+<center>
+  <table>
+    <tr>
+      <th>Item</th>
+      <th>Image</th>
+      <th>Price</th>
+      <th>Quantity</th>
+      <th>Subtotal</th>
+    </tr>
+  <% @item_orders.each do |item_order|%>
+    <tr>
+    <section id = "item_orders-<%=item_order.id%>">
+        <td><p><%=link_to item_order.item.name, item_path(item_order.item)%></p></td>
+        <td><p><img src= <%= item_order.item.image %>><td><p>
+        <td><p><%= number_to_currency(item_order.price)%></p></td>
+        <td><p><%= item_order.quantity%></p></td>
+      </section>
+    </tr>
+  <% end %>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,8 @@ Rails.application.routes.draw do
   namespace :merchant do
     get "/", to: "dashboard#index", as: :user
     resources :items, only: [:index], as: :user
-    resources :orders, only: [:show], as: :user
+
+    resources :orders, only: [:show]
   end
 
   resources :merchants do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   namespace :merchant do
     get "/", to: "dashboard#index", as: :user
     resources :items, only: [:index], as: :user
+    resources :orders, only: [:show], as: :user
   end
 
   resources :merchants do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,6 @@ Rails.application.routes.draw do
   namespace :merchant do
     get "/", to: "dashboard#index", as: :user
     resources :items, only: [:index], as: :user
-
     resources :orders, only: [:show]
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,19 +16,27 @@ dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', c
 
 #bike_shop items
 tire = bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+bike = bike_shop.items.create(name: "Red Bike", description: "Oldie, but goodie", price: 200, image: "https://i.pinimg.com/originals/9d/5f/29/9d5f29749894957753a9edd9e2358d8b.png", inventory: 10)
 
 #dog_shop items
 pull_toy = dog_shop.items.create(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
 dog_bone = dog_shop.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
 
 #users
-regular_user = User.create!(name: "George Jungle",
+regular_user_1 = User.create!(name: "George Jungle",
               address: "1 Jungle Way",
               city: "Jungleopolis",
               state: "FL",
               zipcode: "77652",
               email: "junglegeorge@email.com",
               password: "Tree123")
+regular_user_2 = User.create!(name: "John Testing",
+              address: "123 Testing Lane",
+              city: "Testico",
+              state: "TE",
+              zipcode: "77639",
+              email: "regular_user_1@email.com",
+              password: "Password123")
 merchant_employee = User.create!(name: "Dwight Schrute",
               address: "175 Beet Rd",
               city: "Scranton",
@@ -55,3 +63,21 @@ admin_user = User.create!(name: "Leslie Knope",
               email: "recoffice@email.com",
               password: "Waffles",
               role: 3)
+
+order_1 = Order.create!(name: "Beth", address: "123 Happy St", city: "Denver", state: "CO", zip: "80205")
+  item_order_1 = ItemOrder.create!(order: order_1, item: tire, quantity: 2, price: tire.price, user: regular_user_1)
+  item_order_1 = ItemOrder.create!(order: order_1, item: bike, quantity: 5, price: bike.price, user: regular_user_1)
+
+order_2 = Order.create(name: "John", address: "123 West St", city: "Golden", state: "CO", zip: "56600")
+  item_order_2 = ItemOrder.create(order: order_2, item: bike, quantity: 12, price: bike.price, user: regular_user_2)
+  item_order_3 = ItemOrder.create(order: order_2, item: dog_bone, quantity: 3, price: dog_bone.price, user: regular_user_2)
+
+order_3 = Order.create(name: "Amber", address: "123 East St", city: "Denver", state: "CO", zip: "80205")
+  item_order_4 = ItemOrder.create(order: order_3, item: pull_toy, quantity: 4, price: pull_toy.price, user: regular_user_1)
+  item_order_5 = ItemOrder.create(order: order_3, item: dog_bone, quantity: 3, price: dog_bone.price * 3, user: regular_user_1)
+  item_order_6 = ItemOrder.create(order: order_3, item: tire, quantity: 1, price: tire.price, user: regular_user_1)
+  item_order_6 = ItemOrder.create(order: order_3, item: bike, quantity: 1, price: bike.price, user: regular_user_1)
+
+order_4 = Order.create(name: "Matt", address: "123 North St", city: "Chicago", state: "IL", zip: "60701")
+  item_order_4 = ItemOrder.create(order: order_3, item: pull_toy, quantity: 4, price: pull_toy.price, user: regular_user_2)
+  item_order_5 = ItemOrder.create(order: order_3, item: dog_bone, quantity: 3, price: dog_bone.price * 3, user: regular_user_2)

--- a/spec/features/users/merchant_users/dashboard_spec.rb
+++ b/spec/features/users/merchant_users/dashboard_spec.rb
@@ -66,4 +66,3 @@
   #     expect(page).to have_content.(@chain.name)
   #   end
   # end
-end

--- a/spec/features/users/merchant_users/dashboard_spec.rb
+++ b/spec/features/users/merchant_users/dashboard_spec.rb
@@ -1,37 +1,39 @@
-require 'rails_helper'
+#DEAD TEST TO BE DELETED
 
-RSpec.describe "Merchant Dashboard" do
-  before :each do
-    @bike_shop = Merchant.create!(name: "Brian's Bike Shop",
-                  address: '123 Bike Rd.',
-                  city: 'Richmond',
-                  state: 'VA',
-                  zip: 23137)
-
-    @chain = @bike_shop.items.create!(name: "Chain",
-                  description: "It'll never break!",
-                  price: 50,
-                  image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588",
-                  inventory: 5)
-
-    @merchant_admin = @bike_shop.users.create!(name: "Michael Scott",
-                  address: "1725 Slough Ave",
-                  city: "Scranton",
-                  state: "PA",
-                  zipcode: "18501",
-                  email: "michael.s@email.com",
-                  password: "WorldBestBoss",
-                  role: 2)
-    @merchant_employee = @bike_shop.users.create!(name: "Dwight Schrute",
-                  address: "1725 Slough Ave",
-                  city: "Scranton",
-                  state: "PA",
-                  zipcode: "18501",
-                  email: "dwight@email.com",
-                  password: "MichaelIsTheBest",
-                  role: 1)
-
-  end
+# require 'rails_helper'
+#
+# RSpec.describe "Merchant Dashboard" do
+#   before :each do
+#     @bike_shop = Merchant.create!(name: "Brian's Bike Shop",
+#                   address: '123 Bike Rd.',
+#                   city: 'Richmond',
+#                   state: 'VA',
+#                   zip: 23137)
+#
+#     @chain = @bike_shop.items.create!(name: "Chain",
+#                   description: "It'll never break!",
+#                   price: 50,
+#                   image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588",
+#                   inventory: 5)
+#
+#     @merchant_admin = @bike_shop.users.create!(name: "Michael Scott",
+#                   address: "1725 Slough Ave",
+#                   city: "Scranton",
+#                   state: "PA",
+#                   zipcode: "18501",
+#                   email: "michael.s@email.com",
+#                   password: "WorldBestBoss",
+#                   role: 2)
+#     @merchant_employee = @bike_shop.users.create!(name: "Dwight Schrute",
+#                   address: "1725 Slough Ave",
+#                   city: "Scranton",
+#                   state: "PA",
+#                   zipcode: "18501",
+#                   email: "dwight@email.com",
+#                   password: "MichaelIsTheBest",
+#                   role: 1)
+#
+#   end
 
   # xit 'merchant admin sees link to view shop items' do
   #   allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant_admin)

--- a/spec/features/users/merchant_users/merchant_dashboard_spec.rb
+++ b/spec/features/users/merchant_users/merchant_dashboard_spec.rb
@@ -1,37 +1,40 @@
-require 'rails_helper'
+#DEAD TEST to be deleted
 
-RSpec.describe "Merchant Dashboard" do
-  before :each do
-    @bike_shop = Merchant.create!(name: "Brian's Bike Shop",
-                  address: '123 Bike Rd.',
-                  city: 'Richmond',
-                  state: 'VA',
-                  zip: 23137)
-
-    @chain = @bike_shop.items.create!(name: "Chain",
-                  description: "It'll never break!",
-                  price: 50,
-                  image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588",
-                  inventory: 5)
-
-    @merchant_admin = @bike_shop.users.create!(name: "Michael Scott",
-                  address: "1725 Slough Ave",
-                  city: "Scranton",
-                  state: "PA",
-                  zipcode: "18501",
-                  email: "michael.s@email.com",
-                  password: "WorldBestBoss",
-                  role: 2)
-    @merchant_employee = @bike_shop.users.create!(name: "Dwight Schrute",
-                  address: "1725 Slough Ave",
-                  city: "Scranton",
-                  state: "PA",
-                  zipcode: "18501",
-                  email: "dwight@email.com",
-                  password: "MichaelIsTheBest",
-                  role: 1)
-
-  end
+# require 'rails_helper'
+#
+#
+# RSpec.describe "Merchant Dashboard" do
+#   before :each do
+#     @bike_shop = Merchant.create!(name: "Brian's Bike Shop",
+#                   address: '123 Bike Rd.',
+#                   city: 'Richmond',
+#                   state: 'VA',
+#                   zip: 23137)
+#
+#     @chain = @bike_shop.items.create!(name: "Chain",
+#                   description: "It'll never break!",
+#                   price: 50,
+#                   image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588",
+#                   inventory: 5)
+#
+#     @merchant_admin = @bike_shop.users.create!(name: "Michael Scott",
+#                   address: "1725 Slough Ave",
+#                   city: "Scranton",
+#                   state: "PA",
+#                   zipcode: "18501",
+#                   email: "michael.s@email.com",
+#                   password: "WorldBestBoss",
+#                   role: 2)
+#     @merchant_employee = @bike_shop.users.create!(name: "Dwight Schrute",
+#                   address: "1725 Slough Ave",
+#                   city: "Scranton",
+#                   state: "PA",
+#                   zipcode: "18501",
+#                   email: "dwight@email.com",
+#                   password: "MichaelIsTheBest",
+#                   role: 1)
+#
+#   end
 
   # xit 'merchant admin sees link to view shop items' do
   #   allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant_admin)

--- a/spec/features/users/merchant_users/merchant_dashboard_spec.rb
+++ b/spec/features/users/merchant_users/merchant_dashboard_spec.rb
@@ -1,4 +1,4 @@
-#DEAD TEST to be deleted
+# DEAD TEST to be deleted
 
 # require 'rails_helper'
 #
@@ -67,4 +67,3 @@
   #     expect(page).to have_content.(@chain.name)
   #   end
   # end
-end

--- a/spec/features/users/merchant_users/orders/show_spec.rb
+++ b/spec/features/users/merchant_users/orders/show_spec.rb
@@ -1,52 +1,42 @@
 require 'rails_helper'
 
-
-# As a merchant employee or admin
-# When I visit an order show page from my dashboard
-# I see the customer's name and address
-# I only see the items in the order that are being purchased from my merchant
-# I do not see any items in the order being purchased from other merchants
-# For each item, I see the following information:
-# - the name of the item, which is a link to my item's show page OK
-# - an image of the item
-# - my price for the item
-# - the quantity the user wants to purchase
-
 RSpec.describe "Merchant Order Show Page" do
   before :each do
 
     @regular_user_1 = create(:user)
 
-    # Using to test ONLY merchant_1_shop items appear
     @merchant_shop_1 = create(:merchant, name: "Merchant Shop 1")
       @item_1 = @merchant_shop_1.items.create!(attributes_for(:item, name: "Item 1" ))
       @item_2 = @merchant_shop_1.items.create!(attributes_for(:item, name: "Item 2"))
 
-    # Using to test ONLY merchant_1_shop items appear
     @merchant_shop_2 = create(:merchant, name: "Merchant Shop 2")
       @item_3 = @merchant_shop_2.items.create!(attributes_for(:item, name: "Item 3"))
       @item_4 = @merchant_shop_2.items.create!(attributes_for(:item, name: "Item 4"))
 
     @order_1 = create(:order)
-      #merchant_shop_1 order
-      @item_order_1 = @regular_user_1.item_orders.create!(order: @order_1, item: @item_1, quantity: 2, price: @item_1.price)
-      @item_order_2 = @regular_user_1.item_orders.create!(order: @order_1, item: @item_2, quantity: 8, price: @item_2.price)
-      #merchant_shop_2 order
-      @item_order_3 = @regular_user_1.item_orders.create!(order: @order_1, item: @item_3, quantity: 10, price: @item_3.price)
+      @item_order_1 = @regular_user_1.item_orders.create!(order: @order_1, item: @item_1, quantity: 2, price: @item_1.price, user: @regular_user_1)
+      @item_order_2 = @regular_user_1.item_orders.create!(order: @order_1, item: @item_2, quantity: 8, price: @item_2.price, user: @regular_user_1)
+      @item_order_3 = @regular_user_1.item_orders.create!(order: @order_1, item: @item_3, quantity: 10, price: @item_3.price, user: @regular_user_1)
 
     @order_2 = create(:order)
-      #merchant_shop_1 order, should not appear in order_1 merchant show page
-      @item_order_4 = @regular_user_1.item_orders.create!(order: @order_2, item: @item_2, quantity: 18, price: @item_2.price)
+      @item_order_4 = @regular_user_1.item_orders.create(order: @order_2, item: @item_2, quantity: 18, price: @item_2.price, user: @regular_user_1)
 
     @merchant_admin_1 = create(:user, role: 1, merchant: @merchant_shop_1)
     @merchant_employee_1 = create(:user, role: 2, merchant: @merchant_shop_1)
-
   end
 
   it 'can show all the merchants orders' do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant_admin_1)
 
     visit merchant_order_path(@order_1)
+
+    within "#shipping-address" do
+      expect(page).to have_content(@order_1.name)
+      expect(page).to have_content(@order_1.address)
+      expect(page).to have_content(@order_1.city)
+      expect(page).to have_content(@order_1.state)
+      expect(page).to have_content(@order_1.zip)
+    end
 
     within "#item_orders-#{@item_order_1.id}" do
       expect(page).to have_content(@item_order_1.item.name)
@@ -66,6 +56,5 @@ RSpec.describe "Merchant Order Show Page" do
     expect(page).not_to have_content(@item_order_3.item.name)
 
     expect(page).not_to have_css("#item_orders-#{@item_order_4.id}")
-    save_and_open_page
   end
 end

--- a/spec/features/users/merchant_users/orders/show_spec.rb
+++ b/spec/features/users/merchant_users/orders/show_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe "Merchant Order Show Page" do
+  before :each do
+
+    @regular_user_1 = create(:user)
+
+    @merchant_shop_1 = create(:merchant)
+
+    @item_1 = @merchant_shop_1.items.create!(attributes_for(:item))
+    @item_2 = @merchant_shop_1.items.create!(attributes_for(:item))
+
+    @order_1 = create(:order)
+      @item_order_1 = @regular_user_1.item_orders.create!(order: @order_1, item: @item_1, quantity: 1, price: @item_1.price)
+      @item_order_2 = @regular_user_1.item_orders.create!(order: @order_1, item: @item_2, quantity: 3, price: @item_2.price)
+
+    @merchant_admin = create(:user, role: 1, merchant: @merchant_shop_1)
+    @merchant_employee = create(:user, role: 2, merchant: @merchant_shop_1)
+  end
+
+  it 'can show all the merchants orders' do
+    # binding.pry
+    # @item_1.item_orders -> item_orders for item
+    # @merchant_admin.merchant.item_orders --> orders associated with merchant user
+    # @merchant_shop_1.item_orders --> orders associated with merchant shop
+  end
+end

--- a/spec/features/users/merchant_users/orders/show_spec.rb
+++ b/spec/features/users/merchant_users/orders/show_spec.rb
@@ -21,11 +21,14 @@ RSpec.describe "Merchant Order Show Page" do
     @order_2 = create(:order)
       @item_order_4 = @regular_user_1.item_orders.create(order: @order_2, item: @item_2, quantity: 18, price: @item_2.price, user: @regular_user_1)
 
+    @order_3 = create(:order)
+      @item_order_5 = @regular_user_1.item_orders.create(order: @order_3, item: @item_4, quantity: 18, price: @item_4.price, user: @regular_user_1)
+
     @merchant_admin_1 = create(:user, role: 1, merchant: @merchant_shop_1)
     @merchant_employee_1 = create(:user, role: 2, merchant: @merchant_shop_1)
   end
 
-  it 'can show all the merchants orders' do
+  it 'can only show details about the order pertaining to that merchant' do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant_admin_1)
 
     visit merchant_order_path(@order_1)
@@ -38,23 +41,37 @@ RSpec.describe "Merchant Order Show Page" do
       expect(page).to have_content(@order_1.zip)
     end
 
-    within "#item_orders-#{@item_order_1.id}" do
+    within "#item-orders-#{@item_order_1.id}" do
       expect(page).to have_content(@item_order_1.item.name)
       expect(page).to have_link("Item 1")
       expect(page).to have_css("img[src*='#{@item_order_1.item.image}']")
       expect(page).to have_content(@item_order_1.item.price)
     end
 
-    within "#item_orders-#{@item_order_2.id}" do
+    within "#item-orders-#{@item_order_2.id}" do
       expect(page).to have_content(@item_order_2.item.name)
       expect(page).to have_link("Item 2")
       expect(page).to have_css("img[src*='#{@item_order_2.item.image}']")
       expect(page).to have_content(@item_order_2.item.price)
     end
+  end
+
+  it 'cannot show details pertaining to other merchant' do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant_admin_1)
+
+    visit merchant_order_path(@order_1)
 
     expect(page).not_to have_css("#item_orders-#{@item_order_3.id}")
     expect(page).not_to have_content(@item_order_3.item.name)
 
     expect(page).not_to have_css("#item_orders-#{@item_order_4.id}")
+  end
+
+  it 'merchant user cannot see the shipping information if not their order' do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant_admin_1)
+
+    visit merchant_order_path(@order_3)
+
+    expect(page).to have_content("The page you were looking for doesn't exist (404)")
   end
 end

--- a/spec/features/users/merchant_users/orders/show_spec.rb
+++ b/spec/features/users/merchant_users/orders/show_spec.rb
@@ -46,20 +46,18 @@ RSpec.describe "Merchant Order Show Page" do
   it 'can show all the merchants orders' do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant_admin_1)
 
-    visit merchant_user_order_path(@order_1)
-
+    visit merchant_order_path(@order_1)
 
     within "#item_orders-#{@item_order_1.id}" do
       expect(page).to have_content(@item_order_1.item.name)
-      expect(page).to have_link(item_path(@item_order_1.item))
+      expect(page).to have_link("Item 1")
       expect(page).to have_css("img[src*='#{@item_order_1.item.image}']")
       expect(page).to have_content(@item_order_1.item.price)
-      expect(page).not_to have_content(@item_order_4.item.price)
     end
 
     within "#item_orders-#{@item_order_2.id}" do
       expect(page).to have_content(@item_order_2.item.name)
-      expect(page).to have_link(item_path(@item_order_2.item))
+      expect(page).to have_link("Item 2")
       expect(page).to have_css("img[src*='#{@item_order_2.item.image}']")
       expect(page).to have_content(@item_order_2.item.price)
     end
@@ -68,5 +66,6 @@ RSpec.describe "Merchant Order Show Page" do
     expect(page).not_to have_content(@item_order_3.item.name)
 
     expect(page).not_to have_css("#item_orders-#{@item_order_4.id}")
+    save_and_open_page
   end
 end

--- a/spec/features/users/merchant_users/orders/show_spec.rb
+++ b/spec/features/users/merchant_users/orders/show_spec.rb
@@ -1,27 +1,72 @@
 require 'rails_helper'
 
+
+# As a merchant employee or admin
+# When I visit an order show page from my dashboard
+# I see the customer's name and address
+# I only see the items in the order that are being purchased from my merchant
+# I do not see any items in the order being purchased from other merchants
+# For each item, I see the following information:
+# - the name of the item, which is a link to my item's show page OK
+# - an image of the item
+# - my price for the item
+# - the quantity the user wants to purchase
+
 RSpec.describe "Merchant Order Show Page" do
   before :each do
 
     @regular_user_1 = create(:user)
 
-    @merchant_shop_1 = create(:merchant)
+    # Using to test ONLY merchant_1_shop items appear
+    @merchant_shop_1 = create(:merchant, name: "Merchant Shop 1")
+      @item_1 = @merchant_shop_1.items.create!(attributes_for(:item, name: "Item 1" ))
+      @item_2 = @merchant_shop_1.items.create!(attributes_for(:item, name: "Item 2"))
 
-    @item_1 = @merchant_shop_1.items.create!(attributes_for(:item))
-    @item_2 = @merchant_shop_1.items.create!(attributes_for(:item))
+    # Using to test ONLY merchant_1_shop items appear
+    @merchant_shop_2 = create(:merchant, name: "Merchant Shop 2")
+      @item_3 = @merchant_shop_2.items.create!(attributes_for(:item, name: "Item 3"))
+      @item_4 = @merchant_shop_2.items.create!(attributes_for(:item, name: "Item 4"))
 
     @order_1 = create(:order)
-      @item_order_1 = @regular_user_1.item_orders.create!(order: @order_1, item: @item_1, quantity: 1, price: @item_1.price)
-      @item_order_2 = @regular_user_1.item_orders.create!(order: @order_1, item: @item_2, quantity: 3, price: @item_2.price)
+      #merchant_shop_1 order
+      @item_order_1 = @regular_user_1.item_orders.create!(order: @order_1, item: @item_1, quantity: 2, price: @item_1.price)
+      @item_order_2 = @regular_user_1.item_orders.create!(order: @order_1, item: @item_2, quantity: 8, price: @item_2.price)
+      #merchant_shop_2 order
+      @item_order_3 = @regular_user_1.item_orders.create!(order: @order_1, item: @item_3, quantity: 10, price: @item_3.price)
 
-    @merchant_admin = create(:user, role: 1, merchant: @merchant_shop_1)
-    @merchant_employee = create(:user, role: 2, merchant: @merchant_shop_1)
+    @order_2 = create(:order)
+      #merchant_shop_1 order, should not appear in order_1 merchant show page
+      @item_order_4 = @regular_user_1.item_orders.create!(order: @order_2, item: @item_2, quantity: 18, price: @item_2.price)
+
+    @merchant_admin_1 = create(:user, role: 1, merchant: @merchant_shop_1)
+    @merchant_employee_1 = create(:user, role: 2, merchant: @merchant_shop_1)
+
   end
 
   it 'can show all the merchants orders' do
-    # binding.pry
-    # @item_1.item_orders -> item_orders for item
-    # @merchant_admin.merchant.item_orders --> orders associated with merchant user
-    # @merchant_shop_1.item_orders --> orders associated with merchant shop
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant_admin_1)
+
+    visit merchant_user_order_path(@order_1)
+
+
+    within "#item_orders-#{@item_order_1.id}" do
+      expect(page).to have_content(@item_order_1.item.name)
+      expect(page).to have_link(item_path(@item_order_1.item))
+      expect(page).to have_css("img[src*='#{@item_order_1.item.image}']")
+      expect(page).to have_content(@item_order_1.item.price)
+      expect(page).not_to have_content(@item_order_4.item.price)
+    end
+
+    within "#item_orders-#{@item_order_2.id}" do
+      expect(page).to have_content(@item_order_2.item.name)
+      expect(page).to have_link(item_path(@item_order_2.item))
+      expect(page).to have_css("img[src*='#{@item_order_2.item.image}']")
+      expect(page).to have_content(@item_order_2.item.price)
+    end
+
+    expect(page).not_to have_css("#item_orders-#{@item_order_3.id}")
+    expect(page).not_to have_content(@item_order_3.item.name)
+
+    expect(page).not_to have_css("#item_orders-#{@item_order_4.id}")
   end
 end

--- a/spec/features/users/merchant_users/orders/show_spec.rb
+++ b/spec/features/users/merchant_users/orders/show_spec.rb
@@ -14,15 +14,15 @@ RSpec.describe "Merchant Order Show Page" do
       @item_4 = @merchant_shop_2.items.create!(attributes_for(:item, name: "Item 4", inventory: 10))
 
     @order_1 = create(:order)
-      @item_order_1 = @regular_user_1.item_orders.create!(order: @order_1, item: @item_1, quantity: 2, price: @item_1.price, user: @regular_user_1)
-      @item_order_2 = @regular_user_1.item_orders.create!(order: @order_1, item: @item_2, quantity: 8, price: @item_2.price, user: @regular_user_1)
-      @item_order_3 = @regular_user_1.item_orders.create!(order: @order_1, item: @item_3, quantity: 10, price: @item_3.price, user: @regular_user_1)
+      @item_order_1 = @regular_user_1.item_orders.create!(order: @order_1, item: @item_1, quantity: 2, price: @item_1.price, user: @regular_user_1, status: "pending")
+      @item_order_2 = @regular_user_1.item_orders.create!(order: @order_1, item: @item_2, quantity: 8, price: @item_2.price, user: @regular_user_1, status: "pending")
+      @item_order_3 = @regular_user_1.item_orders.create!(order: @order_1, item: @item_3, quantity: 10, price: @item_3.price, user: @regular_user_1, status: "pending")
 
     @order_2 = create(:order)
-      @item_order_4 = @regular_user_1.item_orders.create(order: @order_2, item: @item_2, quantity: 18, price: @item_2.price, user: @regular_user_1)
+      @item_order_4 = @regular_user_1.item_orders.create(order: @order_2, item: @item_2, quantity: 18, price: @item_2.price, user: @regular_user_1, status: "pending")
 
     @order_3 = create(:order)
-      @item_order_5 = @regular_user_1.item_orders.create(order: @order_3, item: @item_4, quantity: 18, price: @item_4.price, user: @regular_user_1)
+      @item_order_5 = @regular_user_1.item_orders.create(order: @order_3, item: @item_4, quantity: 18, price: @item_4.price, user: @regular_user_1, status: "pending")
 
     @merchant_admin_1 = create(:user, role: 1, merchant: @merchant_shop_1)
     @merchant_employee_1 = create(:user, role: 2, merchant: @merchant_shop_1)
@@ -92,21 +92,20 @@ RSpec.describe "Merchant Order Show Page" do
     visit merchant_order_path(@order_1)
 
     within "#item-orders-#{@item_order_1.id}" do
-      expect(page).to have_content("Pending")
-      click_link("Fullfill Order")
+      click_link("Fulfill Item")
     end
 
-    expect(path).to eq(merchant_order_path(@order_1))
+    expect(current_path).to eq(merchant_order_path(@order_1))
 
     within "#item-orders-#{@item_order_1.id}" do
-      expect(page).to have_content("Fullfilled")
+      expect(page).to have_content("Fulfilled")
     end
 
     within "#item-orders-#{@item_order_2.id}" do
       expect(page).to have_content("Pending")
     end
 
-    expect(page).to have_content("Item order #{@item_order_1.id} has been fullfilled")
+    expect(page).to have_content("Item order #{@item_order_1.id} has been fulfilled")
     expect(@item_order_1.item.quantity).to eq(8)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -20,7 +20,6 @@ describe User, type: :model do
   describe "relationships" do
     it {should have_many :item_orders}
     it {should belong_to(:merchant).optional }
-    it {should have_many (:items).through(:merchant)}
   end
 
   describe "roles" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -101,4 +101,27 @@ describe User, type: :model do
       expect(user_2).to_not be_valid
     end
   end
+
+  describe "methods" do
+    it 'can find item orders by merchant user with order id' do
+      regular_user_1 = create(:user)
+
+      merchant_shop_1 = create(:merchant, name: "Merchant Shop 1")
+        item_1 = merchant_shop_1.items.create!(attributes_for(:item, name: "Item 1" ))
+        item_2 = merchant_shop_1.items.create!(attributes_for(:item, name: "Item 2"))
+
+      order_1 = create(:order)
+        item_order_1 = regular_user_1.item_orders.create!(order: order_1, item: item_1, quantity: 2, price: item_1.price, user: regular_user_1)
+        item_order_2 = regular_user_1.item_orders.create!(order: order_1, item: item_2, quantity: 8, price: item_2.price, user: regular_user_1)
+
+      order_2 = create(:order)
+        item_order_4 = regular_user_1.item_orders.create(order: order_2, item: item_2, quantity: 18, price: item_2.price, user: regular_user_1)
+
+      merchant_admin = create(:user, role: 1, merchant: merchant_shop_1)
+
+      expected = [item_order_1, item_order_2]
+
+      expect(expected).to eq(merchant_admin.item_orders_by_merchant(order_1))
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -19,8 +19,8 @@ describe User, type: :model do
 
   describe "relationships" do
     it {should have_many :item_orders}
-    it { should belong_to(:merchant).optional }
-    #it {should have_many (:items).through(:merchant)}
+    it {should belong_to(:merchant).optional }
+    it {should have_many (:items).through(:merchant)}
   end
 
   describe "roles" do
@@ -84,7 +84,7 @@ describe User, type: :model do
     before(:each) do
       user_1 = create(:user, email: "bob@gmail.com")
     end
-    
+
     it "a different type of user has valid attributes" do
       regular_user = create(:user)
       merchant_employee = create(:user, role: 1)


### PR DESCRIPTION
- Merchant user can view order show page and see information pertaining to them. (item_orders pertaining to them)
- Merchant user cannot see item_orders pertaining to other merchants
- If merchant user has no item_orders under the order,  merchant user redirected to 404 page
- New route created with merchant order show page

- Rspec OK 
- SimpleCov OK 