### PR TITLE
User story 37

### DIFF
--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -1,5 +1,12 @@
 class Merchant::ItemsController < Merchant::BaseController
   def index
-    @items = current_user.merchant.items
+    @items = Item.where(merchant_id: current_user.merchant_id)
+  end
+
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy if item.no_orders?
+    flash[:delete_item_warning] = "#{item.name} is now deleted!"
+    redirect_to merchant_user_index_path
   end
 end

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -12,6 +12,7 @@
           <th scope="col">Price</th>
           <th scope="col">Quantity</th>
           <th scope="col">Active?</th>
+          <th scope="col"></th>
         </tr>
       </thead>
 
@@ -20,12 +21,15 @@
           <section id='item-<%= item.id %>'>
               <tr>
                 <td><%= item.name %> </td>
-                  <td><%= item.id %></td>
+                  <td>#<%= item.id %></td>
                 <td><img id='thumbnail-<%= item.id %>'><%= image_tag item.image, class: 'img_thumbnail' %></img></td>
                 <td><%= item.description %></td>
                 <td><%= item.price %></td>
                 <td><%= item.inventory %></td>
                 <td><%= item.active? %></td>
+                <% if item.no_orders? %>
+                  <td><%= link_to "Delete", "/merchant/items/#{item.id}", method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-danger item-buttons" %></td>
+                <% end %>
               </tr>
           </section>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   namespace :merchant do
     get "/", to: "dashboard#index", as: :user
     get "/orders/:id", to: "dashboard#show", as: :orders_show
-    resources :items, only: [:index], as: :user
+    resources :items, only: [:index, :destroy], as: :user
   end
 
   resources :merchants do

--- a/spec/features/users/merchant_users/item_delete_spec.rb
+++ b/spec/features/users/merchant_users/item_delete_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe "Merchant Items Page" do
+  describe "As a merchant admin" do
+    before :each do
+      shop = create(:merchant)
+      # item attributes are randomly generated; there may be duplicates.
+      # To avoid this scenario, item name is explicitly assigned.
+      @item_1 = shop.items.create!(attributes_for(:item, name: "apple"))  # order placed, cannot delete
+      @item_2 = shop.items.create!(attributes_for(:item, name: "orange")) # order not placed, can delete
+
+      user = create(:user)
+      order = create(:order)
+      item_order = user.item_orders.create!(order: order, item: @item_1, quantity: 1, price: @item_1.price)
+
+      merchant_admin = create(:user, role: 2, merchant: shop)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_admin)
+      visit merchant_user_index_path
+    end
+
+    it "I see a link to delete the item next to each item that has never been ordered" do
+
+      within "#item-#{@item_1.id}" do
+        expect(page).to_not have_link("Delete")
+      end
+
+      within "#item-#{@item_2.id}" do
+        expect(page).to have_link("Delete")
+      end
+    end
+
+    it "once the item is deleted, I see a flash message and I no longer see the item on the page" do
+
+      within "#item-#{@item_2.id}" do
+        click_link "Delete"
+      end
+
+      expect(current_path).to eq(merchant_user_index_path)
+      expect(page).to have_content("#{@item_2.name} is now deleted!")
+      expect(page).to_not have_content("##{@item_2.id}")
+      expect(page).to have_content("##{@item_1.id}")
+    end
+  end
+end


### PR DESCRIPTION
Merchant can delete items
- Add additional column in merchant items table to include a delete link
- the link is visible only when items are not ordered
- Had to modify merchant_items#index method, because in the older version of #index method, @items variable didn't reflect the changes made in #destroy method

-Note: Sometimes, stubbed items (created by factory bot) can have duplicate data. In those cases, 2 items can have the same name/image/etc, which could mess up a delete spec test with `expect(page).to have_content(item.name)`. 