### PR TITLE
Sad path testing 

### DIFF
--- a/app/models/http_url_validator.rb
+++ b/app/models/http_url_validator.rb
@@ -1,0 +1,16 @@
+class HttpUrlValidator < ActiveModel::EachValidator
+
+  def self.compliant?(value)
+    uri = URI.parse(value)
+    uri.is_a?(URI::HTTP) && !uri.host.nil?
+  rescue URI::InvalidURIError
+    false
+  end
+
+  def validate_each(record, attribute, value)
+    unless value.present? && self.class.compliant?(value)
+      record.errors.add(attribute, "is not a valid HTTP URL")
+    end
+  end
+
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,12 +1,12 @@
 class Item <ApplicationRecord
   belongs_to :merchant
-  has_many :reviews
+  has_many :reviews, :dependent => :destroy
   has_many :item_orders
   has_many :orders, through: :item_orders
   has_many :users, through: :merchant
 
   validates_presence_of :name, :description, :price, :inventory
-  validates :image, presence: true, allow_blank: true
+  validates :image, presence: true, http_url: true, allow_blank: true
   validates_inclusion_of :active?, :in => [true, false]
   validates_numericality_of :price, greater_than: 0
   validates_numericality_of :inventory, greater_than_or_equal_to: 0, only_integer: true

--- a/spec/features/users/merchant_users/add_item_spec.rb
+++ b/spec/features/users/merchant_users/add_item_spec.rb
@@ -95,6 +95,28 @@ RSpec.describe "Merchant Items Page" do
           expect(page).to have_css("img[src*='https://avatars3.githubusercontent.com/u/6475745?s=88&v=4']")
         end
       end
+
+      describe "If I put in an invalid image url" do
+        it "I get a flash message and redirect back to form page" do
+          visit new_merchant_user_path
+
+          name = "Chamois Buttr"
+          price = 18
+          description = "No more chaffin'!"
+          image = "foo.png"
+          inventory = 25
+
+          fill_in "Name", with: name
+          fill_in "Price", with: price
+          fill_in "Description", with: description
+          fill_in "Image", with: image
+          fill_in "Inventory", with: inventory
+
+          click_button "Create Item"
+
+          expect(page).to have_content("Image is not a valid HTTP URL")
+        end
+      end
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -5,6 +5,7 @@ describe Item, type: :model do
     it { should validate_presence_of :name }
     it { should validate_presence_of :description }
     it { should allow_value(nil).for(:image) }
+    it { should_not allow_value("foo.png").for(:image) }
     it { should validate_numericality_of :price }
     it { should validate_numericality_of(:inventory).only_integer }
     it { should validate_inclusion_of(:active?).in_array([true,false]) }


### PR DESCRIPTION
- When a merchant admin tries to add a new item and submits an invalid image url (ex. `foo.png`), a flash message pops up. In order to implement this function, I had to add a new class called `HttpUrlValidator` that would take care of url validation

- Add dependent destroy on reviews within item model